### PR TITLE
Build compile time dependencies with all targets

### DIFF
--- a/src/proc_macros.rs
+++ b/src/proc_macros.rs
@@ -29,6 +29,7 @@ pub(crate) fn build_compile_time_dependencies(
         .arg("--message-format")
         .arg("json")
         .arg("--keep-going")
+        .arg("--all-targets")
         .arg("--manifest-path")
         .arg(manifest_path)
         // .arg("-Zunstable-options")


### PR DESCRIPTION
Adds `--all-targets` to the `cargo` command we run to build compile time dependencies. This is necessary to correctly build proc macros and run build scripts for targets other than lib/bin.