### PR TITLE
feat: Filter metadata with current target triple

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ use std::process::{Command, Stdio};
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
+use cargo_metadata::MetadataCommand;
 use cargo_metadata::camino::Utf8PathBuf;
-use cargo_metadata::{CargoOpt, MetadataCommand};
 use clap::Parser;
 use rust_project::ProjectJson;
 use tracing::level_filters::LevelFilter;
@@ -162,8 +162,7 @@ fn discover(ctx: &Context, manifest_path: FilePath<'_>) -> Result<()> {
         .find_map(|line| line.strip_prefix("host: "));
     log_progress("Fetching metadata")?;
     let mut cmd = MetadataCommand::new();
-    cmd.features(CargoOpt::AllFeatures)
-        .manifest_path(manifest_path);
+    cmd.manifest_path(manifest_path);
 
     if let Some(cargo_home) = ctx.cargo_home.as_ref() {
         cmd.cargo_path(cargo_home.join("cargo"));


### PR DESCRIPTION
Attempts to find the current target triple via `rustc` and passes it to
`cargo metadata` via the `--filter-platform` flag. This removes any
crates from the metadata that can't be compiled on the current platform.
