### PR TITLE
bug: Loosen file path requirement for discover command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,7 +99,7 @@ pub struct CheckArgs {
 #[derive(PartialEq, Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum DiscoverArgument {
-    Path(FilePathBuf),
+    Path(Utf8PathBuf),
     Buildfile(FilePathBuf),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,7 +248,7 @@ fn discover(ctx: &Context, discover_args: DiscoverArgs, manifest_path: FilePath<
 }
 
 fn check(ctx: &Context, command: &'static str, args: CheckArgs) -> Result<()> {
-    let manifest = find_manifest(args.path)?;
+    let manifest = find_manifest(args.path.into())?;
     let message_format = if ctx.is_tty {
         "--message-format=human"
     } else if args.disable_color_diagnostics {
@@ -281,7 +281,7 @@ fn check(ctx: &Context, command: &'static str, args: CheckArgs) -> Result<()> {
     }
 }
 
-fn find_manifest(path: FilePathBuf) -> Result<FilePathBuf> {
+fn find_manifest(path: Utf8PathBuf) -> Result<FilePathBuf> {
     let path = std::path::absolute(&path)?;
     let Some(parent) = path.parent() else {
         anyhow::bail!("Invalid path: could not get parent");


### PR DESCRIPTION
Previously, we were expecting the path passed to `DiscoverArgument::Path`
to be path to a file that already exists. However, it's possible that
rust-analyzer will invoke us with a path to a not-yet-existing file if
the user has opened a new file in their editor but hasn't yet saved.
This commit removes the requirement that this path point to a file on
disk to improve UX in this situation.
