### PR TITLE
bug: Add lib targets as deps for bin/test targets in same crate

### DIFF
--- a/src/rust_project.rs
+++ b/src/rust_project.rs
@@ -494,11 +494,11 @@ impl PackageGraph {
                 .targets
                 .iter()
                 .enumerate()
-                .filter_map(|(i, target)| {
-                    matches!(TargetKind::new(&target.kind), TargetKind::Lib)
-                        // I *think* this is the right way to handle target names in this
-                        // context...
-                        .then(|| (crates.len() + i, target.name.clone().replace('-', "_")))
+                .filter(|(_, target)| matches!(TargetKind::new(&target.kind), TargetKind::Lib))
+                .map(|(i, target)| {
+                    // I *think* this is the right way to handle target names in this
+                    // context...
+                    (crates.len() + i, target.name.clone().replace('-', "_"))
                 })
                 .collect();
 


### PR DESCRIPTION
Fixes a bug where public items from lib targets were not accessible to
bin/test targets in the same crate. This is accomplished by including
any lib targets in a given crate as dependencies of bin/test targets in
the same crate.

Fixes #28