### PR TITLE
bug: Fix bin name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ name = "cargo_subspace"
 path = "src/lib.rs"
 
 [[bin]]
-name = "cargo_subspace"
+name = "cargo-subspace"
 path = "src/main.rs"


### PR DESCRIPTION
Switches the binary name from `cargo_subspace` back to `cargo-subspace`,
which is the format required for `cargo` extensions.
